### PR TITLE
Enable threaded and async helpers for Python tools

### DIFF
--- a/benchmarks/scan_benchmark.py
+++ b/benchmarks/scan_benchmark.py
@@ -1,0 +1,37 @@
+import os
+import time
+
+import pysegy as seg
+from pysegy.scan import _scan_file
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+PATTERN = 'overthrust_2D_shot_*.segy'
+FILES = [
+    os.path.join(DATA_DIR, f)
+    for f in os.listdir(DATA_DIR)
+    if f.startswith('overthrust_2D_shot_')
+]
+FILES.sort()
+
+
+def scan_serial():
+    scans = [_scan_file(f) for f in FILES]
+    fh = scans[0].fileheader
+    records = []
+    for sc in scans:
+        records.extend(sc.records)
+    return seg.SegyScan(fh, records)
+
+
+def main():
+    t0 = time.perf_counter()
+    scan_serial()
+    t1 = time.perf_counter()
+    seg.segy_scan(DATA_DIR, PATTERN)
+    t2 = time.perf_counter()
+    print(f"Sequential: {t1 - t0:.3f}s")
+    print(f"Parallel:   {t2 - t1:.3f}s")
+
+
+if __name__ == '__main__':
+    main()

--- a/pysegy/__init__.py
+++ b/pysegy/__init__.py
@@ -8,9 +8,21 @@ from .types import (
     FileHeader,
     SeisBlock,
 )
-from .read import read_fileheader, read_traceheader, read_file, segy_read
-from .scan import SegyScan, segy_scan
-from .write import write_fileheader, write_traceheader, write_block, segy_write
+from .read import (
+    read_fileheader,
+    read_traceheader,
+    read_file,
+    segy_read,
+    segy_read_async,
+)
+from .scan import SegyScan, segy_scan, segy_scan_async
+from .write import (
+    write_fileheader,
+    write_traceheader,
+    write_block,
+    segy_write,
+    segy_write_async,
+)
 
 __all__ = [
     "BinaryFileHeader",
@@ -22,9 +34,12 @@ __all__ = [
     "read_traceheader",
     "read_file",
     "segy_read",
+    "segy_read_async",
     "segy_scan",
+    "segy_scan_async",
     "write_fileheader",
     "write_traceheader",
     "write_block",
     "segy_write",
+    "segy_write_async",
 ]

--- a/pysegy/read.py
+++ b/pysegy/read.py
@@ -12,6 +12,7 @@ from .types import (
     TH_INT32_FIELDS,
 )
 from typing import BinaryIO, Iterable, List, Optional, Tuple
+import asyncio
 
 from .ibm import ibm_to_ieee
 import struct
@@ -204,3 +205,11 @@ def segy_read(path: str, keys: Optional[Iterable[str]] = None) -> SeisBlock:
     """
     with open(path, "rb") as f:
         return read_file(f, keys=keys)
+
+
+async def segy_read_async(
+    path: str, keys: Optional[Iterable[str]] = None
+) -> SeisBlock:
+    """Asynchronously read a SEGY file using a thread."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, segy_read, path, keys)

--- a/pysegy/tests/test_async.py
+++ b/pysegy/tests/test_async.py
@@ -1,0 +1,65 @@
+import os
+import asyncio
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)
+
+import pysegy as seg  # noqa: E402
+from pysegy.types import FileHeader, BinaryTraceHeader, SeisBlock  # noqa: E402
+
+DATAFILE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "data",
+    "overthrust_2D_shot_1_20.segy",
+)
+
+
+def test_segy_read_async():
+    block = asyncio.run(seg.segy_read_async(DATAFILE))
+    assert block.fileheader.bfh.ns == 751
+    assert len(block.traceheaders) == 3300
+    assert block.traceheaders[0].SourceX == 400
+    assert block.traceheaders[0].GroupX == 100
+
+
+def test_async_write_roundtrip(tmp_path):
+    async def run():
+        fh = FileHeader()
+        fh.bfh.ns = 4
+        fh.bfh.DataSampleFormat = 5
+        headers = [BinaryTraceHeader() for _ in range(2)]
+        for th in headers:
+            th.ns = 4
+            th.SourceX = 1234
+        data = [[float(i*j) for j in range(2)] for i in range(4)]
+        block = SeisBlock(fh, headers, data)
+        tmp = tmp_path / "temp_async.segy"
+        await seg.segy_write_async(str(tmp), block)
+        out = await seg.segy_read_async(str(tmp))
+        assert out.fileheader.bfh.ns == 4
+        assert out.traceheaders[0].SourceX == 1234
+        assert out.data == data
+
+    asyncio.run(run())
+
+
+def test_segy_scan_async_directory_pattern():
+    data_dir = os.path.join(os.path.dirname(__file__), "..", "..", "data")
+    scan = asyncio.run(
+        seg.segy_scan_async(
+            data_dir,
+            "overthrust_2D_shot_*.segy",
+            keys=["GroupX"],
+        )
+    )
+    assert isinstance(scan, seg.SegyScan)
+    assert len(scan.shots) == 97
+    assert len(set(scan.paths)) == 5
+    idx = 0
+    assert scan.paths[idx].endswith("overthrust_2D_shot_1_20.segy")
+    assert scan.counts[idx] == 127
+    assert scan.summary(idx)["GroupX"] == (100, 6400)

--- a/pysegy/write.py
+++ b/pysegy/write.py
@@ -4,6 +4,7 @@ Writing utilities for the minimal Python SEGY implementation.
 
 import struct
 from typing import BinaryIO
+import asyncio
 from .types import (
     SeisBlock,
     FileHeader,
@@ -116,3 +117,9 @@ def segy_write(path: str, block: SeisBlock) -> None:
     """
     with open(path, "wb") as f:
         write_block(f, block)
+
+
+async def segy_write_async(path: str, block: SeisBlock) -> None:
+    """Asynchronously write ``block`` to ``path`` using a thread."""
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, segy_write, path, block)


### PR DESCRIPTION
## Summary
- parallelize SEGY scanning via `ThreadPoolExecutor`
- add async wrappers to `segy_scan`, `segy_read` and `segy_write`
- export async helpers in Python package
- add tests for async helpers and a benchmark script

## Testing
- `flake8 pysegy benchmarks`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685985da346c832fac7875a0dd0f36b1