### PR TITLE
Add save/load helpers for SegyScan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "numpy>=2,<3",
     "fsspec>=2024.3",
+    "cloudpickle>=3",
 ]
 
 [project.optional-dependencies]

--- a/pysegy/__init__.py
+++ b/pysegy/__init__.py
@@ -17,7 +17,7 @@ from .read import (
     read_file,
     segy_read,
 )
-from .scan import SegyScan, segy_scan
+from .scan import SegyScan, segy_scan, save_scan, load_scan
 from .write import (
     write_fileheader,
     write_traceheader,
@@ -36,6 +36,8 @@ __all__ = [
     "read_file",
     "segy_read",
     "segy_scan",
+    "save_scan",
+    "load_scan",
     "write_fileheader",
     "write_traceheader",
     "write_block",

--- a/pysegy/tests/test_python.py
+++ b/pysegy/tests/test_python.py
@@ -223,3 +223,22 @@ def test_scan_unsorted_traces(tmp_path):
     assert scan.shots[0] == (1, 1, 0)
     assert scan.counts == [2, 1]
     assert scan.summary(0)["GroupX"] == (1, 3)
+
+
+def test_save_and_load_scan(tmp_path):
+    scan = seg.segy_scan(DATAFILE)
+    dest = tmp_path / "scan.pkl"
+    seg.save_scan(str(dest), scan)
+    out = seg.load_scan(str(dest))
+    assert isinstance(out, seg.SegyScan)
+    assert out.shots == scan.shots
+    assert out.counts == scan.counts
+
+
+def test_save_and_load_scan_fs(tmp_path):
+    fs = fsspec.filesystem("file")
+    scan = seg.segy_scan(DATAFILE)
+    dest = tmp_path / "scan_fs.pkl"
+    seg.save_scan(str(dest), scan, fs=fs)
+    out = seg.load_scan(str(dest), fs=fs)
+    assert out.shots == scan.shots

--- a/pysegy/types.py
+++ b/pysegy/types.py
@@ -206,6 +206,13 @@ class BinaryFileHeader:
 
     __repr__ = __str__
 
+    def __getstate__(self):
+        return {"values": self.values, "keys_loaded": self.keys_loaded}
+
+    def __setstate__(self, state):
+        super().__setattr__("values", state["values"])
+        super().__setattr__("keys_loaded", state["keys_loaded"])
+
 
 @dataclass
 class FileHeader:
@@ -251,6 +258,13 @@ class BinaryTraceHeader:
 
     def __repr__(self):
         return self.__str__()
+
+    def __getstate__(self):
+        return {"values": self.values, "keys_loaded": self.keys_loaded}
+
+    def __setstate__(self, state):
+        super().__setattr__("values", state["values"])
+        super().__setattr__("keys_loaded", state["keys_loaded"])
 
     def __str__(self):
         """Return a multi-line representation of loaded fields."""


### PR DESCRIPTION
## Summary
- enable saving/loading SegyScan objects
- expose helpers in package API
- test saving/loading with and without fsspec filesystems
- serialize SegyScan using cloudpickle

## Testing
- `pytest -q pysegy/tests`

------
https://chatgpt.com/codex/tasks/task_e_6859fc5393b0832f9ab02ea6352bad3d