### PR TITLE
Add scaled header utility

### DIFF
--- a/pysegy/__init__.py
+++ b/pysegy/__init__.py
@@ -24,6 +24,7 @@ from .write import (
     write_block,
     segy_write,
 )
+from .utils import get_header
 
 __all__ = [
     "BinaryFileHeader",
@@ -42,6 +43,7 @@ __all__ = [
     "write_traceheader",
     "write_block",
     "segy_write",
+    "get_header",
 ]
 
 logging.basicConfig(level=logging.INFO)

--- a/pysegy/tests/test_python.py
+++ b/pysegy/tests/test_python.py
@@ -264,3 +264,26 @@ def test_rec_coordinates():
     coords = rec.rec_coordinates
     assert coords.shape[0] == scan.counts[0]
     assert tuple(coords[0]) == (100, 0, 0)
+
+
+def test_get_header_scaling():
+    fh = FileHeader()
+    fh.bfh.ns = 1
+    fh.bfh.DataSampleFormat = 5
+
+    h1 = BinaryTraceHeader()
+    h1.ns = 1
+    h1.SourceX = 10
+    h1.RecSourceScalar = 2
+
+    h2 = BinaryTraceHeader()
+    h2.ns = 1
+    h2.SourceX = 20
+    h2.RecSourceScalar = -2
+
+    block = SeisBlock(fh, [h1, h2], np.zeros((1, 2), dtype=np.float32))
+
+    vals = seg.get_header(block, "SourceX")
+    assert vals == [20, 10]
+    raw = seg.get_header(block, "SourceX", scale=False)
+    assert raw == [10, 20]

--- a/pysegy/utils.py
+++ b/pysegy/utils.py
@@ -1,0 +1,62 @@
+from typing import Iterable, List, Union
+
+from .types import BinaryTraceHeader, SeisBlock
+
+_RECSRC_FIELDS = {
+    "SourceX",
+    "SourceY",
+    "GroupX",
+    "GroupY",
+    "CDPX",
+    "CDPY",
+}
+
+_ELEV_FIELDS = {
+    "RecGroupElevation",
+    "SourceSurfaceElevation",
+    "SourceDepth",
+    "RecDatumElevation",
+    "SourceDatumElevation",
+    "SourceWaterDepth",
+    "GroupWaterDepth",
+}
+
+
+def _check_scale(name: str) -> tuple[bool, str]:
+    if name in _RECSRC_FIELDS:
+        return True, "RecSourceScalar"
+    if name in _ELEV_FIELDS:
+        return True, "ElevationScalar"
+    return False, ""
+
+
+def get_header(
+    src: Union[SeisBlock, Iterable[BinaryTraceHeader]],
+    name: str,
+    *,
+    scale: bool = True,
+) -> List[float]:
+    """Return values for ``name`` from ``src`` optionally applying scaling."""
+    if isinstance(src, SeisBlock):
+        headers = src.traceheaders
+    else:
+        headers = list(src)
+
+    vals = [getattr(h, name) for h in headers]
+
+    scalable, scale_name = _check_scale(name)
+    if scale and scalable:
+        scaled: List[float] = []
+        for h, v in zip(headers, vals):
+            fact = getattr(h, scale_name)
+            if fact > 0:
+                scaled.append(v * fact)
+            elif fact < 0:
+                scaled.append(v / abs(fact))
+            else:
+                scaled.append(v)
+        return scaled
+    return vals
+
+
+__all__ = ["get_header"]


### PR DESCRIPTION
## Summary
- add `get_header` helper to compute scaled trace headers
- export `get_header` from the Python package
- test header scaling behaviour
- ensure flake8 compliance for `utils`

## Testing
- `flake8`
- `pytest -k get_header_scaling -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af238d520832fade928a340aefa6f