### PR TITLE
Fix scaled coordinates in ShotRecord

### DIFF
--- a/pysegy/scan.py
+++ b/pysegy/scan.py
@@ -15,6 +15,7 @@ import cloudpickle
 
 from . import logger
 from .read import read_fileheader, read_traceheader, read_traces
+from .utils import get_header
 from .types import (
     SeisBlock,
     FileHeader,
@@ -29,7 +30,7 @@ class ShotRecord:
     """Information about a single shot location within a SEGY file."""
 
     path: str
-    coordinates: Tuple[int, int, int]
+    coordinates: Tuple[float, float, float]
     fileheader: FileHeader
     rec_depth_key: str = "GroupWaterDepth"
     segments: List[Tuple[int, int]] = field(default_factory=list)
@@ -105,17 +106,18 @@ class ShotRecord:
         """Array of receiver coordinates for this shot."""
         if self._rec_coords is None:
             hdrs = self.read_headers(
-                keys=["GroupX", "GroupY", self.rec_depth_key]
+                keys=[
+                    "GroupX",
+                    "GroupY",
+                    self.rec_depth_key,
+                    "RecSourceScalar",
+                    "ElevationScalar",
+                ]
             )
-            coords = [
-                (
-                    h.GroupX,
-                    h.GroupY,
-                    getattr(h, self.rec_depth_key),
-                )
-                for h in hdrs
-            ]
-            self._rec_coords = np.asarray(coords, dtype=int)
+            gx = get_header(hdrs, "GroupX")
+            gy = get_header(hdrs, "GroupY")
+            dz = get_header(hdrs, self.rec_depth_key)
+            self._rec_coords = np.column_stack((gx, gy, dz)).astype(np.float32)
         return self._rec_coords
 
 
@@ -404,6 +406,8 @@ def _scan_file(
         "GroupX",
         "GroupY",
         rec_depth_key,
+        "RecSourceScalar",
+        "ElevationScalar",
     ]
     if keys is not None:
         for k in keys:
@@ -436,7 +440,11 @@ def _scan_file(
             trace_keys,
             chunk,
         ):
-            src = (th.SourceX, th.SourceY, getattr(th, depth_key))
+            src = (
+                np.float32(get_header([th], "SourceX")[0]),
+                np.float32(get_header([th], "SourceY")[0]),
+                np.float32(get_header([th], depth_key)[0]),
+            )
 
             rec = records.get(src)
             if rec is None:

--- a/pysegy/scan.py
+++ b/pysegy/scan.py
@@ -148,8 +148,11 @@ def _parse_header(buf: bytes, keys: Iterable[str]) -> BinaryTraceHeader:
     return th
 
 
-def _update_summary(summary: Dict[str, Tuple[int, int]], th: BinaryTraceHeader,
-                    keys: Iterable[str]) -> None:
+def _update_summary(
+    summary: Dict[str, Tuple[float, float]],
+    th: BinaryTraceHeader,
+    keys: Iterable[str],
+) -> None:
     """
     Update ``summary`` with values from ``th``.
 
@@ -163,7 +166,7 @@ def _update_summary(summary: Dict[str, Tuple[int, int]], th: BinaryTraceHeader,
         Header fields to include in the summary.
     """
     for k in keys:
-        v = getattr(th, k)
+        v = get_header([th], k)[0]
         if k in summary:
             mn, mx = summary[k]
             if v < mn:

--- a/pysegy/tests/test_python.py
+++ b/pysegy/tests/test_python.py
@@ -221,7 +221,7 @@ def test_scan_unsorted_traces(tmp_path):
 
     scan = seg.segy_scan(str(tmp), keys=["GroupX"])
     assert len(scan.shots) == 2
-    assert scan.shots[0] == (1, 1, 0)
+    assert scan.shots[0] == (1.0, 1.0, 0.0)
     assert scan.counts == [2, 1]
     assert scan.summary(0)["GroupX"] == (1, 3)
 
@@ -263,7 +263,7 @@ def test_rec_coordinates():
     rec = scan[0]
     coords = rec.rec_coordinates
     assert coords.shape[0] == scan.counts[0]
-    assert tuple(coords[0]) == (100, 0, 0)
+    assert tuple(coords[0]) == (100.0, 0.0, 0.0)
 
 
 def test_get_header_scaling():


### PR DESCRIPTION
## Summary
- ensure `ShotRecord` uses RecSourceScalar and ElevationScalar
- reuse `get_header` to scale source and receiver coordinates
- optimize assembling receiver coordinates
- store coordinates and rec_coordinates as `float32`

## Testing
- `pytest -q`
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2411b5b8832f85ea2408c682fc14