### PR TITLE
Parallel trace decoding and vectorized IBM float conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ pytest -vs
 
 The tests run automatically on GitHub Actions with coverage reports uploaded to Codecov.
 
+## Read benchmark
+
+The read benchmark compares median throughput, speedup, and parallel
+efficiency for multiple process counts:
+
+```bash
+python benchmarks/read_benchmark.py /path/to/large.segy --workers 1 2 4 8
+```
+
+Use a representative large file and repeat the benchmark on the target
+storage system. Small files commonly run faster with one worker because
+process startup and inter-process transfer costs outweigh parallel decoding.
+
 ## Inspiration
 
 This project started as a lightweight port of the Julia package

--- a/benchmarks/read_benchmark.py
+++ b/benchmarks/read_benchmark.py
@@ -1,0 +1,78 @@
+"""Benchmark sequential and process-parallel SEGY decoding.
+
+Run from the repository root, for example::
+
+    python benchmarks/read_benchmark.py survey.segy --workers 1 2 4 8
+
+Use a representative large file: process startup and IPC costs deliberately
+make multiprocessing unattractive for small inputs.
+"""
+
+import argparse
+import os
+import statistics
+import time
+
+import pysegy as seg
+
+
+def benchmark(path, workers, repeat):
+    """Return elapsed read times while verifying every run reads all traces."""
+    timings = []
+    expected_traces = None
+    for _ in range(repeat):
+        started = time.perf_counter()
+        block = seg.segy_read(path, workers=workers)
+        timings.append(time.perf_counter() - started)
+        traces = len(block.traceheaders)
+        if expected_traces is None:
+            expected_traces = traces
+        elif traces != expected_traces:
+            raise RuntimeError("benchmark runs returned different trace counts")
+    return timings, expected_traces
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare sequential and parallel SEGY read throughput"
+    )
+    parser.add_argument("path", help="SEGY file to read")
+    parser.add_argument(
+        "--workers", type=int, nargs="+", default=[1, 2, 4],
+        help="worker counts to compare (default: 1 2 4)",
+    )
+    parser.add_argument(
+        "--repeat", type=int, default=3,
+        help="number of reads per worker count (default: 3)",
+    )
+    args = parser.parse_args()
+    if args.repeat < 1:
+        parser.error("--repeat must be at least 1")
+    if any(worker < 1 for worker in args.workers):
+        parser.error("--workers values must be at least 1")
+
+    size_mib = os.path.getsize(args.path) / 1024 ** 2
+    results = []
+    for workers in args.workers:
+        timings, traces = benchmark(args.path, workers, args.repeat)
+        median = statistics.median(timings)
+        results.append((workers, median, size_mib / median))
+        samples = ", ".join(f"{timing:.3f}" for timing in timings)
+        print(f"workers={workers}: [{samples}] seconds ({traces} traces)")
+
+    baseline = next(
+        (elapsed for workers, elapsed, _ in results if workers == 1),
+        results[0][1],
+    )
+    print("\nworkers  median (s)  MiB/s    speedup  efficiency")
+    for workers, elapsed, throughput in results:
+        speedup = baseline / elapsed
+        efficiency = speedup / workers
+        print(
+            f"{workers:7d}  {elapsed:10.3f}  {throughput:7.1f}  "
+            f"{speedup:7.2f}x  {efficiency:9.1%}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/pysegy/ibm.py
+++ b/pysegy/ibm.py
@@ -36,10 +36,13 @@ def ibm_to_ieee(value: Union[bytes, bytearray, int]) -> float:
     return sign * mant * 16 ** (exponent - 64)
 
 
-def ibm_to_ieee_array(buf: bytes, count: int, bigendian: bool = True) -> np.ndarray:
-    """Vectorized conversion of ``count`` IBM floats contained in ``buf``."""
-    dtype = ">u4" if bigendian else "<u4"
-    vals = np.frombuffer(buf, dtype=dtype, count=count)
+def ibm_words_to_ieee(vals: np.ndarray) -> np.ndarray:
+    """Convert an array of IBM floating-point words to IEEE floats.
+
+    ``vals`` may be strided.  This is useful for decoding samples interleaved
+    with SEGY trace headers without first copying every trace into a separate
+    bytes object.
+    """
     sign = np.where(vals >> 31 == 0, 1.0, -1.0)
     exponent = (vals >> 24) & 0x7F
     fraction = vals & 0x00FFFFFF
@@ -47,6 +50,13 @@ def ibm_to_ieee_array(buf: bytes, count: int, bigendian: bool = True) -> np.ndar
     out = sign * mant * np.power(16.0, exponent.astype(np.float64) - 64)
     out[vals == 0] = 0.0
     return out.astype(np.float32)
+
+
+def ibm_to_ieee_array(buf: bytes, count: int, bigendian: bool = True) -> np.ndarray:
+    """Vectorized conversion of ``count`` IBM floats contained in ``buf``."""
+    dtype = ">u4" if bigendian else "<u4"
+    vals = np.frombuffer(buf, dtype=dtype, count=count)
+    return ibm_words_to_ieee(vals)
 
 
 def ieee_to_ibm(f: float) -> bytes:

--- a/pysegy/read.py
+++ b/pysegy/read.py
@@ -11,14 +11,70 @@ from .types import (
     TH_BYTE2SAMPLE,
 )
 from typing import BinaryIO, Iterable, List, Optional, Tuple
+from concurrent.futures import Future, ProcessPoolExecutor
+import multiprocessing
 import numpy as np
-from concurrent.futures import ThreadPoolExecutor
-
-from .utils import read_samples, unpack_int, open_file
+from .utils import unpack_int, open_file
+from .ibm import ibm_words_to_ieee
 from . import vprint
 
 # Number of traces to read at a time when loading an entire file
 TRACE_CHUNKSIZE = 512
+
+
+def _decode_trace_bytes(
+    raw: bytes,
+    ns: int,
+    ntraces: int,
+    datatype: int,
+    keys: Optional[Iterable[str]],
+    bigendian: bool,
+) -> Tuple[List[BinaryTraceHeader], np.ndarray]:
+    """Decode one self-contained trace chunk.
+
+    This module-level function is intentionally pickleable so large reads can
+    decode independent chunks in worker processes rather than GIL-bound
+    threads.  File I/O stays in the parent process, which also supports remote
+    and file-like objects that cannot be reopened by a worker.
+    """
+    if ntraces == 0:
+        return [], np.empty((ns, 0), dtype=np.float32)
+
+    trace_size = 240 + ns * 4
+    expected = trace_size * ntraces
+    if len(raw) != expected:
+        raise EOFError(
+            f"Expected {expected} bytes for {ntraces} traces, got {len(raw)}"
+        )
+
+    key_list = list(TH_BYTE2SAMPLE.keys()) if keys is None else list(keys)
+    byteorder = ">" if bigendian else "<"
+    header_columns = {}
+    for key in key_list:
+        offset, size = TH_BYTE2SAMPLE[key]
+        dtype = np.dtype(f"{byteorder}i{size}")
+        header_columns[key] = np.ndarray(
+            (ntraces,), dtype=dtype, buffer=raw, offset=offset,
+            strides=(trace_size,),
+        )
+
+    headers: List[BinaryTraceHeader] = []
+    for idx in range(ntraces):
+        hdr = BinaryTraceHeader()
+        for key, values in header_columns.items():
+            setattr(hdr, key, int(values[idx]))
+        hdr.keys_loaded = key_list
+        headers.append(hdr)
+
+    sample_dtype = np.dtype(f"{byteorder}{'u4' if datatype == 1 else 'f4'}")
+    samples = np.ndarray(
+        (ntraces, ns), dtype=sample_dtype, buffer=raw, offset=240,
+        strides=(trace_size, 4),
+    )
+    if datatype == 1:
+        samples = ibm_words_to_ieee(samples)
+    data = np.asarray(samples, dtype=np.float32).T.copy()
+    return headers, data
 
 
 def read_fileheader(
@@ -101,7 +157,7 @@ def read_traces(
     datatype: int,
     keys: Optional[Iterable[str]] = None,
     bigendian: bool = True,
-) -> Tuple[List[BinaryTraceHeader], List[List[float]]]:
+) -> Tuple[List[BinaryTraceHeader], np.ndarray]:
     """
     Read ``ntraces`` traces and their headers from ``f``.
 
@@ -126,39 +182,9 @@ def read_traces(
         ``(headers, data)`` where ``headers`` is a list of
         :class:`BinaryTraceHeader` and ``data`` is ``ns`` x ``ntraces`` array.
     """
-    data: np.ndarray = np.zeros((ns, ntraces), dtype=np.float32)
-    headers: List[BinaryTraceHeader] = [BinaryTraceHeader() for _ in range(ntraces)]
-
     trace_size = 240 + ns * 4
     raw = f.read(trace_size * ntraces)
-
-    if keys is None:
-        keys = list(TH_BYTE2SAMPLE.keys())
-    key_list = list(keys)
-
-    hdr_parsers = [
-        (k, TH_BYTE2SAMPLE[k][0], TH_BYTE2SAMPLE[k][1]) for k in key_list
-    ]
-
-    def parse_one(idx: int):
-        offset = idx * trace_size
-        hdr_buf = raw[offset:offset + 240]
-        hdr = BinaryTraceHeader()
-        for k, off_k, size_k in hdr_parsers:
-            val = unpack_int(hdr_buf[off_k:off_k + size_k], size_k, bigendian)
-            setattr(hdr, k, val)
-        hdr.keys_loaded = key_list
-
-        data_buf = raw[offset + 240:offset + trace_size]
-        samples = read_samples(data_buf, ns, datatype, bigendian)
-        return idx, hdr, samples
-
-    with ThreadPoolExecutor() as pool:
-        for idx, hdr, samples in pool.map(parse_one, range(ntraces)):
-            headers[idx] = hdr
-            data[:, idx] = samples
-
-    return headers, data
+    return _decode_trace_bytes(raw, ns, ntraces, datatype, keys, bigendian)
 
 
 def read_file(
@@ -182,7 +208,9 @@ def read_file(
     bigendian : bool, optional
         Set ``True`` for big-endian encoding.
     workers : int, optional
-        Unused parameter kept for backwards compatibility.
+        Number of processes used to decode independent trace chunks. Use
+        ``1`` to disable multiprocessing. At most one chunk per worker is
+        pending, bounding the additional memory used for large datasets.
 
     Returns
     -------
@@ -200,17 +228,61 @@ def read_file(
     f.seek(3600)
     headers: List[BinaryTraceHeader] = [BinaryTraceHeader() for _ in range(ntraces)]
     data: np.ndarray = np.zeros((ns, ntraces), dtype=np.float32)
+    key_list = None if keys is None else list(keys)
 
-    idx = 0
-    while idx < ntraces:
-        count = min(TRACE_CHUNKSIZE, ntraces - idx)
-        h, d = read_traces(
-            f, ns, count, dsf, keys, bigendian
-        )
+    if workers < 1:
+        raise ValueError("workers must be at least 1")
+
+    def store_chunk(start: int, result) -> None:
+        h, d = result
+        count = len(h)
         for j in range(count):
-            headers[idx + j] = h[j]
-            data[:, idx + j] = d[:, j]
-        idx += count
+            headers[start + j] = h[j]
+        data[:, start:start + count] = d
+
+    if workers == 1 or ntraces <= TRACE_CHUNKSIZE:
+        idx = 0
+        while idx < ntraces:
+            count = min(TRACE_CHUNKSIZE, ntraces - idx)
+            store_chunk(
+                idx, read_traces(f, ns, count, dsf, key_list, bigendian)
+            )
+            idx += count
+    else:
+        pending: List[Tuple[int, Future]] = []
+        # ``fork`` also permits library use from notebooks and ``python -c``
+        # on POSIX. Windows only offers spawn and therefore retains Python's
+        # usual requirement that multiprocessing entry points are guarded.
+        methods = multiprocessing.get_all_start_methods()
+        context = multiprocessing.get_context(
+            "fork" if "fork" in methods else methods[0]
+        )
+        with ProcessPoolExecutor(
+            max_workers=workers, mp_context=context
+        ) as pool:
+            idx = 0
+            while idx < ntraces:
+                count = min(TRACE_CHUNKSIZE, ntraces - idx)
+                raw = f.read(trace_size * count)
+                future = pool.submit(
+                    _decode_trace_bytes,
+                    raw,
+                    ns,
+                    count,
+                    dsf,
+                    key_list,
+                    bigendian,
+                )
+                pending.append((idx, future))
+                idx += count
+
+                # Limit queued bytes while keeping every process occupied.
+                if len(pending) >= workers:
+                    start, completed = pending.pop(0)
+                    store_chunk(start, completed.result())
+
+            for start, completed in pending:
+                store_chunk(start, completed.result())
 
     return SeisBlock(fh, headers, data)
 

--- a/pysegy/tests/test_python.py
+++ b/pysegy/tests/test_python.py
@@ -90,6 +90,13 @@ def test_read_traces_rejects_truncated_input():
         seg.read.read_traces(BytesIO(bytes(247)), 2, 1, 5)
 
 
+def test_read_traces_empty_input():
+    headers, data = seg.read.read_traces(BytesIO(), 2, 0, 5)
+    assert headers == []
+    assert data.shape == (2, 0)
+    assert data.dtype == np.float32
+
+
 def test_read_traces_little_endian():
     header = bytearray(240)
     header[0:4] = (123).to_bytes(4, "little", signed=True)

--- a/pysegy/tests/test_python.py
+++ b/pysegy/tests/test_python.py
@@ -85,6 +85,47 @@ def test_write_read_block_bytesio():
     assert np.all(out.data == data)
 
 
+def test_read_traces_rejects_truncated_input():
+    with pytest.raises(EOFError, match="Expected 248 bytes"):
+        seg.read.read_traces(BytesIO(bytes(247)), 2, 1, 5)
+
+
+def test_read_traces_little_endian():
+    header = bytearray(240)
+    header[0:4] = (123).to_bytes(4, "little", signed=True)
+    raw = bytes(header) + np.array([1.5, -2.0], dtype="<f4").tobytes()
+    headers, data = seg.read.read_traces(
+        BytesIO(raw), 2, 1, 5, keys=["TraceNumWithinLine"], bigendian=False
+    )
+    assert headers[0].TraceNumWithinLine == 123
+    assert np.array_equal(data[:, 0], [1.5, -2.0])
+
+
+def test_read_file_parallel_chunks(tmp_path, monkeypatch):
+    monkeypatch.setattr(seg.read, "TRACE_CHUNKSIZE", 1)
+    fh = FileHeader()
+    fh.bfh.ns = 2
+    fh.bfh.DataSampleFormat = 5
+    headers = [BinaryTraceHeader() for _ in range(3)]
+    for index, header in enumerate(headers):
+        header.ns = 2
+        header.SourceX = index + 10
+    expected = np.arange(6, dtype=np.float32).reshape(2, 3)
+    path = tmp_path / "parallel.segy"
+    seg.segy_write(str(path), SeisBlock(fh, headers, expected))
+
+    with path.open("rb") as stream:
+        actual = seg.read.read_file(stream, workers=2)
+
+    assert [header.SourceX for header in actual.traceheaders] == [10, 11, 12]
+    assert np.array_equal(actual.data, expected)
+
+
+def test_read_file_rejects_invalid_workers():
+    with pytest.raises(ValueError, match="workers must be at least 1"):
+        seg.read.read_file(BytesIO(bytes(3600)), workers=0)
+
+
 def test_read_with_filesystem():
     fs = fsspec.filesystem("file")
     block = seg.segy_read(DATAFILE, fs=fs)


### PR DESCRIPTION
### Motivation

- Improve performance and memory efficiency when reading large SEGY files by decoding independent trace chunks in parallel.  
- Allow zero-copy decoding of interleaved samples by supporting strided numpy arrays for IBM-to-IEEE conversion.  
- Make multiprocessing decoding robust for different platforms while keeping file I/O in the parent process so remote/file-like streams are handled correctly.  

### Description

- Added `ibm_words_to_ieee(vals: np.ndarray)` to convert arrays of IBM 32-bit words to IEEE floats and refactored `ibm_to_ieee_array` to call it.  
- Introduced `_decode_trace_bytes(raw, ns, ntraces, datatype, keys, bigendian)` to parse headers and samples from a contiguous raw bytes buffer using `numpy.ndarray` with `buffer` and `strides`, returning `(headers, data)`.  
- Reworked `read_traces` to delegate to the new `_decode_trace_bytes`, and updated `read_file` to optionally decode chunks in parallel using `ProcessPoolExecutor` with a bounded queue of pending tasks and a platform-aware start method.  
- Added validation for `workers >= 1`, preserved single-process behavior when `workers == 1`, and ensured IBM-format samples are decoded via the new vectorized path.  

### Testing

- Added unit tests `test_read_traces_rejects_truncated_input`, `test_read_traces_little_endian`, `test_read_file_parallel_chunks`, and `test_read_file_rejects_invalid_workers` to cover truncation handling, little-endian decoding, parallel chunked reads, and invalid worker values.  
- Ran the test suite with `pytest` including the new tests and the existing header/read/write tests, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b2e0ffc64832f97101008f501296d)